### PR TITLE
Remove playerStat error, adjusted cohstats URL

### DIFF
--- a/COHOpponentBot_Bot.py
+++ b/COHOpponentBot_Bot.py
@@ -355,7 +355,7 @@ class StatsRequest:
 			if (statdata['result']['message'] == "SUCCESS"):
 				logging.info ("statdata load succeeded")
 				playerStats = PlayerStat(statdata, statnumber)
-			return playerStats
+				return playerStats
 		except Exception as e:
 			logging.info("Problem in returnStats")
 			logging.info(str(e))
@@ -904,7 +904,7 @@ class GameData():
 
 			statList = self.getStatsFromGame()
 
-			print(statList)
+			#print(statList)
 
 			for player in self.playerList:
 				if statList:
@@ -1001,7 +1001,7 @@ class GameData():
 			self.cohRunning = True
 			return True
 		except Exception as e:
-			#logging.info(str(e))
+			logging.info(str(e))
 			self.cohRunning = False
 			return False
 			

--- a/COHOpponentBot_Bot.py
+++ b/COHOpponentBot_Bot.py
@@ -672,7 +672,7 @@ class PlayerStat:
 
 			if self.steamString:
 				self.steamNumber = str(self.steamString).replace("/steam/", "")
-				self.steamProfileAddress = "playercard.cohstats.com/?steamid=" + str(self.steamNumber)
+				self.steamProfileAddress = "cohstats.com/i?d=" + str(self.steamNumber)
 
 
 	


### PR DESCRIPTION
- Removed playerStat.object error. Possible solution? Works for me.
- Game memory keeps refreshing, not sure if this is intended. Log file gives debug on pid for RelicCoH.exe. 
- Changed cohstats URL to a redirect short url to minimize chat space.